### PR TITLE
feat : 소셜 로그인 시 닉네임 문제 해결

### DIFF
--- a/src/shared/firebase.js
+++ b/src/shared/firebase.js
@@ -46,21 +46,40 @@ export const setGithubLogin = async () => {
 
     const userDocRef = doc(db, 'users', user.uid);
     const signUpDate = new Date().toISOString();
+    const generateRandomNickname = () => {
+      const randomNumber = Math.floor(Math.random() * 10000);
+      const formattedNumber = randomNumber.toString().padStart(4, '0');
+      return `익명유저${formattedNumber}`;
+    };
 
-    const nickname = user.displayName || '익명유저';
+    const userDocSnapshot = await getDoc(userDocRef);
+    let nickname;
 
-    const newUser = {
+    if (userDocSnapshot.exists()) {
+      nickname = userDocSnapshot.data().nickname;
+      alert(`안녕하세요, ${nickname}님!`);
+    } else {
+      nickname = user.displayName || generateRandomNickname();
+      await setDoc(userDocRef, {
+        fullEmail: user.email,
+        nickname,
+        status: '',
+        avatar: 'cat',
+        token: '470bf4b0-975d-4d2b-a924-a78554a2b97c',
+        signUpDate
+      });
+      await getUserInfo(user.uid);
+      alert(`안녕하세요, ${nickname}님!`);
+    }
+    return {
       fullEmail: user.email,
       nickname,
       status: '',
       avatar: 'cat',
       token: '470bf4b0-975d-4d2b-a924-a78554a2b97c',
-      signUpDate
+      signUpDate,
+      id: user.uid
     };
-    await setDoc(userDocRef, newUser);
-    await getUserInfo(user.uid);
-    alert(`안녕하세요, ${nickname}님!`);
-    return { ...newUser, id: user.uid };
   } catch (error) {
     console.error(error);
   }
@@ -74,27 +93,40 @@ export const setGooGleLogin = async (dispatch) => {
 
     const userDocRef = doc(db, 'users', user.uid);
     const signUpDate = new Date().toISOString();
-
     const generateRandomNickname = () => {
       const randomNumber = Math.floor(Math.random() * 10000);
       const formattedNumber = randomNumber.toString().padStart(4, '0');
       return `익명유저${formattedNumber}`;
     };
 
-    const nickname = user.displayName || generateRandomNickname();
+    const userDocSnapshot = await getDoc(userDocRef);
+    let nickname;
 
-    const newUser = {
+    if (userDocSnapshot.exists()) {
+      nickname = userDocSnapshot.data().nickname;
+      alert(`안녕하세요, ${nickname}님!`);
+    } else {
+      nickname = user.displayName || generateRandomNickname();
+      await setDoc(userDocRef, {
+        fullEmail: user.email,
+        nickname,
+        status: '',
+        avatar: 'cat',
+        token: '470bf4b0-975d-4d2b-a924-a78554a2b97c',
+        signUpDate
+      });
+      await getUserInfo(user.uid);
+      alert(`안녕하세요, ${nickname}님!`);
+    }
+    return {
       fullEmail: user.email,
       nickname,
       status: '',
       avatar: 'cat',
       token: '470bf4b0-975d-4d2b-a924-a78554a2b97c',
-      signUpDate
+      signUpDate,
+      id: user.uid
     };
-    await setDoc(userDocRef, newUser);
-    await getUserInfo(user.uid);
-    alert(`안녕하세요, ${nickname}님!`);
-    return { ...newUser, id: user.uid };
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
소셜 로그인 할 때 처음에만 닉네임이 자동 생성되게함.
그 후 데이터베이스에 닉네임이 존재 할 경우 닉네임을 재생성하지 않음.

구글이나 깃허브에서 닉네임을 미리 정의했다면 최초 로그인시 미리 정한 닉네임을 가져오고,
그 후 로그인을 할때는 닉네임을 불러오지 않게하여
마이페이지에서 수정된 닉네임이 적용되지 않던 오류를 고침.